### PR TITLE
fixed a comiling error within Visual Studio 2019 on Wnidows and a small typo of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You can also construct more-complex data structures:
 ```c++
 bencode::encode(std::cout, bencode::dict{
   {"one", 1},
-  {"two", bencode::list{1, "foo", 2},
+  {"two", bencode::list{1, "foo", 2}},
   {"three", "3"}
 });
 ```

--- a/include/bencode.hpp
+++ b/include/bencode.hpp
@@ -258,16 +258,16 @@ namespace bencode {
     template<typename Integer>
     inline void check_overflow(Integer value, Integer digit) {
       using limits = std::numeric_limits<Integer>;
-      if((value > limits::max() / 10) ||
-         (value == limits::max() / 10 && digit > limits::max() % 10))
+      if((value > (limits::max)() / 10) ||
+         (value == (limits::max)() / 10 && digit > (limits::max)() % 10))
         throw std::invalid_argument("integer overflow");
     }
 
     template<typename Integer>
     inline void check_underflow(Integer value, Integer digit) {
       using limits = std::numeric_limits<Integer>;
-      if((value < limits::min() / 10) ||
-         (value == limits::min() / 10 && digit < limits::min() % 10))
+      if((value < (limits::min)() / 10) ||
+         (value == (limits::min)() / 10 && digit < (limits::min)() % 10))
         throw std::invalid_argument("integer underflow");
     }
 


### PR DESCRIPTION
hello,
I just tried to compile it on Visual Studio 2019 and get failed.
Then I found that it related to std::min std::max on Visual Studio.

And the typo is in README.md, it will lead a compiling error if the reader just duplicate it simply.