### PR TITLE
Fix typo in bencode::map_proxy::swap() method

### DIFF
--- a/include/bencode.hpp
+++ b/include/bencode.hpp
@@ -68,7 +68,7 @@ namespace bencode {
       return *this;
     }
 
-    void swap(const map_proxy &rhs) { proxy_->swap(*rhs.proxy); }
+    void swap(const map_proxy &rhs) { proxy_->swap(*rhs.proxy_); }
 
     operator map_type &() { return *proxy_; };
     operator const map_type &() const { return *proxy_; };


### PR DESCRIPTION
Due to this the library won't build on clang+libcxx:

```
include/bencode.hpp:71:57: error: no member named 'proxy' in 'map_proxy<Key, Value>'; did you mean 'proxy_'?
   71 |     void swap(const map_proxy &rhs) { proxy_->swap(*rhs.proxy); }
      |                                                         ^~~~~
      |                                                         proxy_
```

Fixes #10 